### PR TITLE
Set RGB and white

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -306,7 +306,7 @@ class FluxLight(Light):
         if self._mode == MODE_RGBW:
             if white is None:
                 self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*color))
-            elif color is None:
+            elif hs_color is None:
                 self._bulb.setRgbw(w=white)
             else:
                 self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*color), w=white)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -306,8 +306,10 @@ class FluxLight(Light):
         if self._mode == MODE_RGBW:
             if white is None:
                 self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*color))
-            else:
+            elif color is None:
                 self._bulb.setRgbw(w=white)
+            else:
+                self._bulb.setRgbw(*color_util.color_hsv_to_RGB(*color), w=white)
         # handle RGB mode
         else:
             self._bulb.setRgb(*color_util.color_hsv_to_RGB(*color))


### PR DESCRIPTION
If both color and white values requested, set full RGBW value.

## Description:

Only the white value was set if both RGB and White value requested.

fixes #23322

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
